### PR TITLE
add spider for Mängelmelder Braunschweig

### DIFF
--- a/OnlineParticipationDataset/spiders/MaengelmelderBraunschweigSpider.py
+++ b/OnlineParticipationDataset/spiders/MaengelmelderBraunschweigSpider.py
@@ -1,0 +1,54 @@
+from typing import Generator
+
+import scrapy
+from scrapy import Selector
+from scrapy.http import HtmlResponse
+
+from OnlineParticipationDataset import items
+from datetime import datetime
+import re
+import locale
+
+from OnlineParticipationDataset.items import SuggestionItem
+
+
+class MaengelmelderBraunschweigSpider(scrapy.Spider):
+    name = "maengelmelder-braunschweig"
+    start_urls = ['https://www.mitreden.braunschweig.de/node/1358']
+
+    def __init__(self, *args, **kwargs):
+        super(MaengelmelderBraunschweigSpider, self).__init__(*args, **kwargs)
+        locale.setlocale(locale.LC_TIME, 'de_DE.UTF-8')
+
+    def parse(self, response: HtmlResponse) -> Generator:
+        """
+        Parse given response and yield items for post in Maengelmelder Braunschweig.
+        """
+        for post in response.css("article.with-categories"):
+            yield MaengelmelderBraunschweigSpider.parse_post(post)
+
+        next_page = response.css("a[title='Zur nächsten Seite']::attr('href')").extract_first()
+        if next_page:
+            yield response.follow(next_page, self.parse)
+
+    @staticmethod
+    def parse_post(article: Selector) -> SuggestionItem:
+        """
+        Parse thread and yield a SuggestionItem, see :class:`~OnlineParticipationDataset.items.SuggestionItem`.
+
+        :param response: scrapy response
+        :return: generator
+        """
+        # suggestion = self.create_suggestion_item(response)
+        # suggestion['comments'] = self.create_comment_item_list(response, suggestion['suggestion_id'])
+        suggestion_item = items.SuggestionItem()
+        suggestion_item['suggestion_id'] = article.css("h3 a::attr('href')").extract_first().replace("/node/", "") # TODO page entfernen
+        suggestion_item['title'] = article.css("h3 a::text").extract_first()
+        suggestion_item['date_time'] = datetime.strptime(article.css("p.user-and-date:first-child::text").extract()[1].strip(), "am %d.%m.%Y")
+        suggestion_item['category'] = article.css(".category_button span::text").extract_first().strip()
+        suggestion_item['author'] = article.css("span.username::text").extract_first()
+        # suggestion_item['approval'] = self.get_suggestion_approval(response)
+        suggestion_item['address'] = article.css("p.user-and-date::text")[-1].extract().strip()
+        suggestion_item['content'] = article.css(".field p::text").extract_first()
+        # suggestion_item['comment_count'] = self.get_suggestion_comment_count(response)
+        return suggestion_item

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ scrapy crawl <dataset>
 | Köln 2013 | [buergerhaushalt.stadt-koeln.de/2013/buergervorschlaege](https://buergerhaushalt.stadt-koeln.de/2013/buergervorschlaege?&sort_bef_combine=php+ASC) | 592 | 3095 | 3687 | 5 minutes | scrapy crawl koeln2013|
 | Köln 2015 | [buergerhaushalt.stadt-koeln.de/2015/buergervorschlaege](https://buergerhaushalt.stadt-koeln.de/2015/buergervorschlaege?&sort_bef_combine=php+ASC) | 631 | 1855 | 2486 | 10 minutes | scrapy crawl koeln2015|
 | Köln 2016 | [buergerhaushalt.stadt-koeln.de/2016/buergervorschlaege](https://buergerhaushalt.stadt-koeln.de/2016/buergervorschlaege?&sort_bef_combine=php+ASC) | 827 | 1314 | 2141 | 9 minutes | scrapy crawl koeln2016|
+| Mängelmelder Braunschweig | [mitreden.braunschweig.de/node/1358](https://www.mitreden.braunschweig.de/node/1358) | ≥ 3220 | | | 34 minutes | scrapy crawl maengelmelder-braunschweig|
 | Raddialog Bonn | [raddialog.bonn.de/dialoge](https://www.raddialog.bonn.de/dialoge/bonner-rad-dialog?sort_bef_combine=created%20ASC) | 2331 | 2425 | 4756 | 16 minutes | scrapy crawl raddialog-bonn|
 | Raddialog Koeln | [raddialog-ehrenfeld.koeln.de/dialoge](http://www.raddialog-ehrenfeld.koeln/dialoge/ehrenfelder-raddialog?sort_bef_combine=created%20ASC) | 378 | 277 | 655 | 2 minutes | scrapy crawl raddialog-koeln|
 | Raddialog Moers | [raddialog.moers.de/dialoge](https://www.raddialog.moers.de/node/1384?sort_bef_combine=created%20ASC) | 463 | 300 | 763 | 3 minutes | scrapy crawl raddialog-moers|


### PR DESCRIPTION
Their list of “all” reports only contains the latest ~200 reports. So instead of following the links from the homepage, I crawl the ID of the latest report and then download the pages for all IDs until I reach the homepage, and check for every page if it actually belongs to the Mängelmelder.